### PR TITLE
batch: configurable rate limiter + lower legacy parallelism (8 → 4)

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -8,10 +8,34 @@ import (
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/shopspring/decimal"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/time/rate"
 
 	"github.com/infrared-dao/protocols/fetchers"
 	"github.com/infrared-dao/protocols/multicall3"
 )
+
+// defaultLegacyParallelism caps concurrent legacy fan-out goroutines when
+// the caller doesn't override via [BatchOptions.LegacyParallelism]. Tuned
+// down from 8 to 4 (2026-06-01) so non-batchable providers cannot dominate
+// a strict-cap RPC provider (e.g. Chainstack Pro at 400 method/s) during a
+// price-tick burst.
+const defaultLegacyParallelism = 4
+
+// BatchOptions tunes the dispatch behavior of
+// [BatchLPTokenPriceWithOptions]. All fields are optional; the zero value
+// is what [BatchLPTokenPrice] uses.
+type BatchOptions struct {
+	// Limiter, when non-nil, gates each RPC dispatch: one token per
+	// Multicall3.aggregate3 invocation in the batched path, and one token
+	// before each legacy fan-out goroutine's LPTokenPrice call. Share the
+	// same limiter instance across calls for a process-wide cap; a fresh
+	// limiter per invocation only smooths an in-flight burst.
+	Limiter *rate.Limiter
+
+	// LegacyParallelism overrides the cap on concurrent legacy fan-out
+	// goroutines. Values <= 0 use defaultLegacyParallelism.
+	LegacyParallelism int
+}
 
 // BatchablePriceProvider is an opt-in extension of [Protocol] that
 // decomposes LP-price computation into a declarative reads-list builder
@@ -99,6 +123,19 @@ func BatchLPTokenPrice(
 	legacyHTTPClient fetchers.HttpClient,
 	queries []BatchPriceQuery,
 ) ([]BatchPriceResult, error) {
+	return BatchLPTokenPriceWithOptions(ctx, multicall, legacyClient, legacyHTTPClient, queries, BatchOptions{})
+}
+
+// BatchLPTokenPriceWithOptions is the configurable variant of
+// [BatchLPTokenPrice]. See [BatchOptions] for tunables.
+func BatchLPTokenPriceWithOptions(
+	ctx context.Context,
+	multicall multicall3Caller,
+	legacyClient bind.ContractBackend,
+	legacyHTTPClient fetchers.HttpClient,
+	queries []BatchPriceQuery,
+	opts BatchOptions,
+) ([]BatchPriceResult, error) {
 	if multicall == nil {
 		return nil, fmt.Errorf("BatchLPTokenPrice: multicall must not be nil")
 	}
@@ -125,6 +162,14 @@ func BatchLPTokenPrice(
 
 	// Dispatch the batched path: one aggregate3 per block partition.
 	for _, indices := range batchableByBlock {
+		if opts.Limiter != nil {
+			if err := opts.Limiter.Wait(ctx); err != nil {
+				for _, idx := range indices {
+					results[idx] = BatchPriceResult{Err: fmt.Errorf("rate limiter wait: %w", err)}
+				}
+				continue
+			}
+		}
 		dispatchBatch(ctx, multicall, queries, indices, results)
 	}
 
@@ -132,11 +177,20 @@ func BatchLPTokenPrice(
 	// existing LPTokenPrice synchronously; errgroup just parallelises them
 	// up to a sane cap so a long tail doesn't dominate wall-clock time.
 	if len(nonBatchable) > 0 {
-		const legacyParallelism = 8
+		legacyCap := defaultLegacyParallelism
+		if opts.LegacyParallelism > 0 {
+			legacyCap = opts.LegacyParallelism
+		}
 		eg, egCtx := errgroup.WithContext(ctx)
-		eg.SetLimit(legacyParallelism)
+		eg.SetLimit(legacyCap)
 		for _, i := range nonBatchable {
 			eg.Go(func() error {
+				if opts.Limiter != nil {
+					if err := opts.Limiter.Wait(egCtx); err != nil {
+						results[i] = BatchPriceResult{Err: fmt.Errorf("rate limiter wait: %w", err)}
+						return nil
+					}
+				}
 				results[i] = runLegacyPriceQuery(egCtx, queries[i])
 				return nil
 			})

--- a/batch_test.go
+++ b/batch_test.go
@@ -4,12 +4,15 @@ import (
 	"context"
 	"errors"
 	"math/big"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
 	"github.com/shopspring/decimal"
+	"golang.org/x/time/rate"
 
 	"github.com/infrared-dao/protocols/fetchers"
 	"github.com/infrared-dao/protocols/multicall3"
@@ -55,9 +58,9 @@ func (f *fakeBatchable) Initialize(context.Context, bind.ContractBackend, fetche
 func (f *fakeBatchable) LPTokenPrice(context.Context) (string, error) {
 	return f.legacyPrice, f.legacyErr
 }
-func (f *fakeBatchable) TVL(context.Context) (string, error)                  { return "", nil }
+func (f *fakeBatchable) TVL(context.Context) (string, error)                       { return "", nil }
 func (f *fakeBatchable) TVLBreakdown(context.Context) (map[string]TokenTVL, error) { return nil, nil }
-func (f *fakeBatchable) UpdateBlock(*big.Int, map[string]Price)               {}
+func (f *fakeBatchable) UpdateBlock(*big.Int, map[string]Price)                    {}
 
 // BatchablePriceProvider extension:
 func (f *fakeBatchable) PriceReads() ([]multicall3.Call3, error) { return f.reads, nil }
@@ -78,10 +81,10 @@ func (f *fakeLegacy) GetConfig(context.Context, string, bind.ContractBackend) ([
 func (f *fakeLegacy) Initialize(context.Context, bind.ContractBackend, fetchers.HttpClient) error {
 	return nil
 }
-func (f *fakeLegacy) LPTokenPrice(context.Context) (string, error)            { return f.price, f.err }
-func (f *fakeLegacy) TVL(context.Context) (string, error)                     { return "", nil }
+func (f *fakeLegacy) LPTokenPrice(context.Context) (string, error)              { return f.price, f.err }
+func (f *fakeLegacy) TVL(context.Context) (string, error)                       { return "", nil }
 func (f *fakeLegacy) TVLBreakdown(context.Context) (map[string]TokenTVL, error) { return nil, nil }
-func (f *fakeLegacy) UpdateBlock(*big.Int, map[string]Price)                  {}
+func (f *fakeLegacy) UpdateBlock(*big.Int, map[string]Price)                    {}
 
 func TestBatchLPTokenPrice_RejectsNilMulticall(t *testing.T) {
 	t.Parallel()
@@ -324,6 +327,115 @@ func TestBatchLPTokenPrice_ZeroReadPartitionStillComputes(t *testing.T) {
 		t.Errorf("results[1].Price = %v, want 11", results[1].Price)
 	}
 }
+
+// BatchOptions.LegacyParallelism must cap concurrent legacy goroutines.
+// With LegacyParallelism=1, peak observed in-flight count for N>1 legacy
+// providers must be exactly 1.
+func TestBatchLPTokenPriceWithOptions_LegacyParallelism(t *testing.T) {
+	t.Parallel()
+
+	var inFlight, peak int64
+	gate := make(chan struct{})
+
+	slowImpl := func(_ context.Context) (string, error) {
+		cur := atomic.AddInt64(&inFlight, 1)
+		for {
+			p := atomic.LoadInt64(&peak)
+			if cur <= p || atomic.CompareAndSwapInt64(&peak, p, cur) {
+				break
+			}
+		}
+		<-gate
+		atomic.AddInt64(&inFlight, -1)
+		return "1", nil
+	}
+
+	const n = 4
+	queries := make([]BatchPriceQuery, n)
+	for i := range queries {
+		queries[i] = BatchPriceQuery{Provider: &gatedLegacy{run: slowImpl}}
+	}
+
+	go func() {
+		// Brief wait so the dispatcher launches and parks the first
+		// goroutine on <-gate before we release them all at once.
+		time.Sleep(50 * time.Millisecond)
+		close(gate)
+	}()
+
+	results, err := BatchLPTokenPriceWithOptions(
+		context.Background(),
+		&fakeMulticall{},
+		nil, nil,
+		queries,
+		BatchOptions{LegacyParallelism: 1},
+	)
+	if err != nil {
+		t.Fatalf("BatchLPTokenPriceWithOptions: %v", err)
+	}
+	if len(results) != n {
+		t.Fatalf("len(results) = %d, want %d", len(results), n)
+	}
+	if got := atomic.LoadInt64(&peak); got != 1 {
+		t.Errorf("peak in-flight = %d, want 1 (LegacyParallelism=1)", got)
+	}
+}
+
+// BatchOptions.Limiter that's already been drained (and a context that
+// times out before the limiter refills) must surface as a per-query error
+// rather than blocking indefinitely.
+func TestBatchLPTokenPriceWithOptions_LimiterRespectsContext(t *testing.T) {
+	t.Parallel()
+
+	// One token total, infinitely slow refill: the first dispatch consumes
+	// the burst budget; subsequent waits must hit ctx deadline.
+	lim := rate.NewLimiter(rate.Limit(0.01), 1)
+	_ = lim.Allow() // drain the burst budget
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	p1 := &fakeBatchable{
+		reads:         []multicall3.Call3{{Target: common.Address{1}, CallData: []byte{1}}},
+		priceFromResp: func([]multicall3.Result3) (decimal.Decimal, error) { return decimal.NewFromInt(1), nil },
+	}
+
+	mc := &fakeMulticall{
+		respFn: func(calls []multicall3.Call3) ([]multicall3.Result3, error) {
+			return []multicall3.Result3{{Success: true}}, nil
+		},
+	}
+
+	results, err := BatchLPTokenPriceWithOptions(
+		ctx, mc, nil, nil,
+		[]BatchPriceQuery{{Provider: p1}},
+		BatchOptions{Limiter: lim},
+	)
+	if err != nil {
+		t.Fatalf("BatchLPTokenPriceWithOptions: %v", err)
+	}
+	if results[0].Err == nil {
+		t.Errorf("expected per-query err when limiter blocks past ctx deadline, got nil")
+	}
+}
+
+// gatedLegacy is a Protocol that delegates LPTokenPrice to a caller-supplied
+// func. Used by the LegacyParallelism test to observe in-flight goroutine
+// counts.
+type gatedLegacy struct {
+	run func(context.Context) (string, error)
+}
+
+func (g *gatedLegacy) GetConfig(context.Context, string, bind.ContractBackend) ([]byte, error) {
+	return nil, nil
+}
+func (g *gatedLegacy) Initialize(context.Context, bind.ContractBackend, fetchers.HttpClient) error {
+	return nil
+}
+func (g *gatedLegacy) LPTokenPrice(ctx context.Context) (string, error)          { return g.run(ctx) }
+func (g *gatedLegacy) TVL(context.Context) (string, error)                       { return "", nil }
+func (g *gatedLegacy) TVLBreakdown(context.Context) (map[string]TokenTVL, error) { return nil, nil }
+func (g *gatedLegacy) UpdateBlock(*big.Int, map[string]Price)                    {}
 
 // Suppress the unused-import warning in case zerolog is removed by a later
 // refactor — keep it referenced so the import block stays stable across

--- a/etherfi.go
+++ b/etherfi.go
@@ -313,17 +313,3 @@ func (e *EtherfiLPPriceProvider) getPrice(tokenKey string) (*Price, error) {
 	}
 	return &price, nil
 }
-
-// getTotalSupply fetches the total supply of the LP token.
-func (e *EtherfiLPPriceProvider) getTotalSupply(ctx context.Context) (*big.Int, error) {
-	opts := &bind.CallOpts{
-		Context:     ctx,
-		BlockNumber: e.block,
-	}
-	totalSupply, err := e.contract.TotalSupply(opts)
-	if err != nil {
-		e.logger.Error().Err(err).Msg("failed to fetch total supply")
-		return nil, err
-	}
-	return totalSupply, nil
-}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/sync v0.19.0
+	golang.org/x/time v0.9.0
 )
 
 require (

--- a/steer.go
+++ b/steer.go
@@ -38,7 +38,6 @@ type SteerLPPriceProvider struct {
 	configBytes []byte
 	config      *SteerConfig
 	contract    *sc.SteerPool
-	httpClient  fetchers.HttpClient
 }
 
 // NewSteerLPPriceProvider creates a new instance of the SteerLPPriceProvider.


### PR DESCRIPTION
## Summary
- Adds `BatchOptions{Limiter, LegacyParallelism}` and `BatchLPTokenPriceWithOptions`; `BatchLPTokenPrice` delegates with zero opts so existing callers are unaffected.
- When `Limiter` is non-nil it consumes one token per `Multicall3.aggregate3` invocation and one per legacy fan-out goroutine, so a single shared `*rate.Limiter` caps both paths process-wide.
- `defaultLegacyParallelism` lowered from 8 → 4. The legacy fan-out can fire many inner `eth_call`s per provider; 8 concurrent providers blew past Chainstack Pro's 400 method/s cap during sulaco price-tick bursts. Callers needing the old value pass `LegacyParallelism: 8`.

## Why
Sulaco's per-minute price tick (60s, 6-field cron) regularly pushes Chainstack Pro past its 400 method/s cap, producing 429s the failover layer rotates around but doesn't eliminate. Tier 2 (parallelism) and Tier 3 (rate limit) are the protocols-side knobs the backend will wire up in a follow-up PR (Tier 1: TOML `max_batch_size` + `block_header` cron stagger).

## Compatibility
No breaking changes. `BatchLPTokenPrice`'s public signature is preserved; new behaviour is opt-in via `BatchLPTokenPriceWithOptions`. The `defaultLegacyParallelism` change does affect every existing caller — it's strictly a cap reduction (more conservative), and any caller that depended on 8 can pin to it via `LegacyParallelism: 8`.

## Test plan
- [x] `go test ./...` (relevant: `TestBatchLPTokenPriceWithOptions_LegacyParallelism`, `TestBatchLPTokenPriceWithOptions_LimiterRespectsContext`)
- [x] Pre-existing tests untouched and still pass
- [ ] Wired into sulaco via follow-up backend PR with `rate.NewLimiter(300, 50)` (300 rps steady, 50 burst)