### PR TITLE
batch: drop BatchOptions.Limiter — throttling belongs at the transport layer (v0.3.0)

### DIFF
--- a/batch.go
+++ b/batch.go
@@ -8,7 +8,6 @@ import (
 	bind "github.com/ethereum/go-ethereum/accounts/abi/bind/v2"
 	"github.com/shopspring/decimal"
 	"golang.org/x/sync/errgroup"
-	"golang.org/x/time/rate"
 
 	"github.com/infrared-dao/protocols/fetchers"
 	"github.com/infrared-dao/protocols/multicall3"
@@ -24,14 +23,15 @@ const defaultLegacyParallelism = 4
 // BatchOptions tunes the dispatch behavior of
 // [BatchLPTokenPriceWithOptions]. All fields are optional; the zero value
 // is what [BatchLPTokenPrice] uses.
+//
+// NOTE: a Limiter field existed in v0.2.x and gated each RPC dispatch with
+// rate.Limiter.Wait(ctx). It was removed in v0.3.0 — rate-shaping outgoing
+// RPC traffic is a transport-layer concern (alongside metrics, retries,
+// failover) and putting it in the domain package conflated two unrelated
+// concerns AND caused real production issues by competing with the per-
+// request ctx deadline. Consumers needing a process-wide cap should wrap
+// their eth_client with a rate-limited transport instead.
 type BatchOptions struct {
-	// Limiter, when non-nil, gates each RPC dispatch: one token per
-	// Multicall3.aggregate3 invocation in the batched path, and one token
-	// before each legacy fan-out goroutine's LPTokenPrice call. Share the
-	// same limiter instance across calls for a process-wide cap; a fresh
-	// limiter per invocation only smooths an in-flight burst.
-	Limiter *rate.Limiter
-
 	// LegacyParallelism overrides the cap on concurrent legacy fan-out
 	// goroutines. Values <= 0 use defaultLegacyParallelism.
 	LegacyParallelism int
@@ -162,14 +162,6 @@ func BatchLPTokenPriceWithOptions(
 
 	// Dispatch the batched path: one aggregate3 per block partition.
 	for _, indices := range batchableByBlock {
-		if opts.Limiter != nil {
-			if err := opts.Limiter.Wait(ctx); err != nil {
-				for _, idx := range indices {
-					results[idx] = BatchPriceResult{Err: fmt.Errorf("rate limiter wait: %w", err)}
-				}
-				continue
-			}
-		}
 		dispatchBatch(ctx, multicall, queries, indices, results)
 	}
 
@@ -185,12 +177,6 @@ func BatchLPTokenPriceWithOptions(
 		eg.SetLimit(legacyCap)
 		for _, i := range nonBatchable {
 			eg.Go(func() error {
-				if opts.Limiter != nil {
-					if err := opts.Limiter.Wait(egCtx); err != nil {
-						results[i] = BatchPriceResult{Err: fmt.Errorf("rate limiter wait: %w", err)}
-						return nil
-					}
-				}
 				results[i] = runLegacyPriceQuery(egCtx, queries[i])
 				return nil
 			})

--- a/batch_test.go
+++ b/batch_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/rs/zerolog"
 	"github.com/shopspring/decimal"
-	"golang.org/x/time/rate"
 
 	"github.com/infrared-dao/protocols/fetchers"
 	"github.com/infrared-dao/protocols/multicall3"
@@ -378,44 +377,6 @@ func TestBatchLPTokenPriceWithOptions_LegacyParallelism(t *testing.T) {
 	}
 	if got := atomic.LoadInt64(&peak); got != 1 {
 		t.Errorf("peak in-flight = %d, want 1 (LegacyParallelism=1)", got)
-	}
-}
-
-// BatchOptions.Limiter that's already been drained (and a context that
-// times out before the limiter refills) must surface as a per-query error
-// rather than blocking indefinitely.
-func TestBatchLPTokenPriceWithOptions_LimiterRespectsContext(t *testing.T) {
-	t.Parallel()
-
-	// One token total, infinitely slow refill: the first dispatch consumes
-	// the burst budget; subsequent waits must hit ctx deadline.
-	lim := rate.NewLimiter(rate.Limit(0.01), 1)
-	_ = lim.Allow() // drain the burst budget
-
-	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
-	defer cancel()
-
-	p1 := &fakeBatchable{
-		reads:         []multicall3.Call3{{Target: common.Address{1}, CallData: []byte{1}}},
-		priceFromResp: func([]multicall3.Result3) (decimal.Decimal, error) { return decimal.NewFromInt(1), nil },
-	}
-
-	mc := &fakeMulticall{
-		respFn: func(calls []multicall3.Call3) ([]multicall3.Result3, error) {
-			return []multicall3.Result3{{Success: true}}, nil
-		},
-	}
-
-	results, err := BatchLPTokenPriceWithOptions(
-		ctx, mc, nil, nil,
-		[]BatchPriceQuery{{Provider: p1}},
-		BatchOptions{Limiter: lim},
-	)
-	if err != nil {
-		t.Fatalf("BatchLPTokenPriceWithOptions: %v", err)
-	}
-	if results[0].Err == nil {
-		t.Errorf("expected per-query err when limiter blocks past ctx deadline, got nil")
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,6 @@ require (
 	github.com/rs/zerolog v1.34.0
 	github.com/shopspring/decimal v1.4.0
 	golang.org/x/sync v0.19.0
-	golang.org/x/time v0.9.0
 )
 
 require (


### PR DESCRIPTION
## Summary

The ``Limiter`` field introduced in v0.2.1 (#80) turned out to be wrong on two counts.

### Wrong layer

Rate-shaping outgoing RPC is a transport concern (alongside metrics, retries, failover). The protocols package's job is to compute LP token prices given some price feeds — putting throttle policy in domain code conflated two unrelated concerns, and meant every other code path inside the consumer service (block_header, TVL collectors, ad-hoc reads) had to silently miss the cap because they don't go through ``BatchLPTokenPrice``.

### Wrong scope: `Limiter.Wait(ctx)` cannibalised the dispatch ctx

The per-dispatch ``Limiter.Wait(ctx)`` call inside this function shared its ``ctx`` with the actual ``eth_call`` dispatch that followed. Time spent parking on the limiter was deducted from the request's deadline budget, so under sustained throttling the limiter wait *plus* the slow upstream response would routinely overshoot the consumer's ``request_timeout``.

Empirically on ``infrared-dao/backend``'s sulaco this produced a measurable regression: 429 share dropped (the limiter capped method/s) but HTTP 499 (\"client closed request\") share **grew by ~2× absolute rate** after deploy of the v0.2.1 wiring. The new ``eth_rpc_inner_errors_total`` metric in [infrared-dao/backend#1526](https://github.com/infrared-dao/backend/pull/1526) caught the downstream effect: per-element ``-32005`` errors from Chainstack continued to land, just dressed up as transport errors instead of HTTP 429s.

## What changes

- ``BatchOptions.Limiter`` field removed.
- ``BatchLPTokenPriceWithOptions`` loses the ``Limiter.Wait`` calls in both the batched-dispatch loop and the legacy fan-out goroutines.
- ``BatchOptions`` retains ``LegacyParallelism`` — that's a legitimate domain knob (\"how aggressively to fan out non-batchable providers\" is a price-computation concern, not a transport one).
- ``BatchLPTokenPrice`` / ``BatchLPTokenPriceWithOptions`` signatures are unchanged beyond the field removal — sulaco's call site just stops setting ``Limiter`` in the ``BatchOptions`` literal.
- ``golang.org/x/time/rate`` dropped from ``go.mod`` direct deps; the ``LimiterRespectsContext`` test is removed alongside.

Doc comment on ``BatchOptions`` records the v0.2.x → v0.3.0 transition rationale so future readers know why the field is gone and point at the right alternative (transport-layer wrapper in the consuming service).

## Compatibility

**Breaking change** vs v0.2.x for any external caller that constructed ``BatchOptions{Limiter: ...}``. Tag this as **v0.3.0**.

Within infrared-dao, the only known consumer is ``infrared-dao/backend``'s sulaco. A coordinated backend PR will (a) bump the protocols dep to v0.3.0, (b) drop the now-orphaned ``batchLimiter`` field on ``ProtocolAdapter`` and the wiring in ``cmd/sulaco/bootstrap.go``, and (c) introduce a new ``RateLimitedClient`` wrapper at the transport layer that applies the same 300-rps cap to *every* outgoing eth_client RPC uniformly — not just the LP price path. That work lands in the backend repo, not here.

## Test plan

- [x] ``go test ./...`` (all green; ``TestBatchLPTokenPriceWithOptions_LimiterRespectsContext`` removed, ``TestBatchLPTokenPriceWithOptions_LegacyParallelism`` retained)
- [x] ``go build ./...``
- [x] ``make lint`` (0 issues)
- [ ] After merge: tag ``v0.3.0``
- [ ] After tag: backend architecture PR opens, bumps dep, removes the misplaced limiter wiring, and lands the transport-layer ``RateLimitedClient``
- [ ] Validation in the backend PR will use the metrics from infrared-dao/backend#1526 + #1527 (the diagnostic metrics PRs that just landed) — specifically that ``eth_rpc_inner_errors_total{caller=\"price_batched\", jsonrpc_code=\"-32005\"}`` collapses toward zero and ``transport_error`` rate on the price-batched caller drops back to where it was before v0.2.1